### PR TITLE
added shortcode template for expandable sections

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1328,3 +1328,9 @@ textarea {
 		font-size: .6875rem;
 	}
 }
+
+summary {
+	font-weight: 700;
+	color: #e22d30;
+	cursor: pointer;
+}

--- a/layouts/shortcodes/details.html
+++ b/layouts/shortcodes/details.html
@@ -1,0 +1,5 @@
+<details>
+  <summary>{{ (.Get 0) | markdownify }}</summary>
+  {{ .Inner | markdownify }}
+</details>
+<br />


### PR DESCRIPTION
Added a new shortcode template that will allow you to have a collapsible div on the page. This div can be clicked to open and show the content on the page, and then clicked again to have the content be hidden.

Example on how to use the shortcode block:

```markdown
{{< details "Click to expand this section for new tests" >}}
Something cool here....
{{< /details >}}
```

Signed-off-by: Scott Westover <scottwestover2006@gmail.com>